### PR TITLE
Настройка логирования

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration
-    xmlns="http://logging.apache.org/log4j/2.0/config"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://logging.apache.org/log4j/2.0/config
-    https://raw.githubusercontent.com/apache/logging-log4j2/master/log4j-core/src/main/resources/Log4j-config.xsd"
-    strict="true"
->
+<Configuration xmlns="https://logging.apache.org/xml/ns"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="
+                   https://logging.apache.org/xml/ns
+                   https://logging.apache.org/xml/ns/log4j-config-2.xsd">
     <Appenders>
-        <Console name="STDOUT_PLAIN" target="SYSTEM_OUT">
+        <Console name="CONSOLE" target="SYSTEM_OUT">
             <PatternLayout
                 disableAnsi="false"
                 pattern="%d{HH:mm:ss.SSS} %highlight{%-5p} [%-15.15thread] %-15.15logger{20} -- %highlight{%m}%n"
@@ -16,15 +14,12 @@
     </Appenders>
 
     <Loggers>
-        <Logger name="com.sun" level="WARN"/>
-        <Logger name="jdk.event.security" level="INFO"/>
-        <Logger name="sun.rmi" level="WARN"/>
-        <Logger name="sun.rmi.transport" level="WARN"/>
-
-        <Logger name="edu" level="TRACE"/>
-
+        <!-- Log everything starting with level INFO to CONSOLE appender -->
         <Root level="INFO">
-            <AppenderRef ref="STDOUT_PLAIN"/>
+            <AppenderRef ref="CONSOLE"/>
         </Root>
+
+        <!-- Log messages from our packages starting with level TRACE -->
+        <Logger name="ru.urfu" level="TRACE"/>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Изменил конфиг логера, ушёл от дефолтного. Теперь в консоль уходят все уровни логов нашего пакета (всё, что лежит в `ru.urfu`). Логи других пакетов уходят в консоль, если уровень уровень их серьёзности превышает `INFO`.

Короче, теперь можешь использовать `LOGGER.debug()` (синий цвет) и `LOGGER.trace()` (чёрный).

Из документации (в порядке уменьшения серьёзности):
- `FATAL` используется для логирования события, после которого программа никак не может продолжать работу.
- `ERROR` используется для логирования ошибок, от которых можно оправиться. 
- `WARN` используется для логирования событий, которые могут потенциально привести к ошибке. 
- `INFO` используется для логирования информационных сообщений.
- `DEBUG` используется для логирования обычного дебажного события.
- `TRACE` используется для логирования дебаг-информации, созданое с целью запечатлить общий ход программы.

Не стесняйся использовать разные уровни. Можешь даже оставлять `LOGGER.debug()` в коде, потому что мы в любой момент можем выключить вывод этих сообщений в консоль. Оставлять их не страшно поэтому. Для этого логер и существует.